### PR TITLE
Initial module scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,48 @@
-# Drupal-gin
+# Drupal Gin
+__Module name:__ `gt/gt_gin`
+For customizations to the Gin admin theme.
+Will be called into the `drupal-admin` recipe.
 
-For customizations to the Gin admin theme
+# Development
+@TODO: Work in progress!
 
-Will be called into the drupal-admin recipe
+## Via local repo
+Modules can be loaded locally in a couple ways, to make it easy to make changes and commit those changes back to the remote repo.
+
+### Save directly to modules directory
+If a module is added directly to the `web/modules/contrib` (or `web/modules/custom`) directory, it will be loaded.
+1. Navigate to the modules directory:
+```bash
+cd web/modules/contrib
+```
+2. Clone the module to the directory, with the module machine name:
+```bash
+git clone https://github.com/gatech-arcs/drupal-gin.git gt_gin
+```
+3. Create a new working branch or swap to an existing one:
+```bash
+cd gt_gin
+git checkout -b $newBranch
+```
+
+### Using Composer with local path
+
+added directly to the `web/modules/contrib`/`web/modules/custom` directory.
+1. Clone the `drupal_gin` repo to your project directory
+
+## Via remote repo
+1. Add an SSO-authorized Personal Access Token to your `git` config
+2. Add the repo to your project's `composer.json` repositories list:
+```bash
+composer config repositories.gt_gin vcs https://github.com/gatech-arcs/drupal-gin.git
+```
+3. Add the module to the Drupal project:
+```bash
+# Dev version of module from master branch
+composer require gt/gt_gin @dev
+
+# Version of module from other branch
+composer require gt/gt_gin:dev-$branchName
+```
+
+This will place the module in `web/modules/contrib/gt_gin`.

--- a/gt_gin.info.yml
+++ b/gt_gin.info.yml
@@ -1,0 +1,7 @@
+name: GT Gin
+type: module
+description: 'Custom theming for Gin admin theme.'
+package: GT
+core_version_requirement: ^10 || ^11
+dependencies:
+  - gin_toolbar:gin_toolbar

--- a/gt_gin.install
+++ b/gt_gin.install
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * Installation checks, borrowed from the gin_toolbar module.
+ */
+
+use Drupal\Core\Installer\InstallerKernel;
+
+/**
+ * Implements hook_requirements().
+ */
+function gt_gin_requirements($phase) {
+  $requirements = [];
+
+  # If it's not the installation phase: skip the requirements check.
+  if ($phase !== 'install') {
+    return $requirements;
+  }
+
+  # If the Gin theme is installed: skip the requirements check.
+  $installed = \Drupal::service('theme_handler')->themeExists('gin');
+  if ($installed) {
+    return $requirements;
+  }
+
+  # If Drupal is being installed and Gin is part of the Drupal installation profile: skip the requirements check.
+  global $install_state;
+  if (InstallerKernel::installationAttempted()
+    && isset($install_state['profile_info']['themes'])
+    && in_array('gin', $install_state['profile_info']['themes'], TRUE)
+  ) {
+    return $requirements;
+  }
+
+  # Otherwise: Gin is not installed, and we need to show an error for the requirements check.
+  $requirements['gin'] = [
+    'title' => t('Gin'),
+    'description' => t('The GT Gin module works with the <a href="https://www.drupal.org/project/gin" target="_blank">Gin</a> theme only'),
+    'severity' => REQUIREMENT_ERROR,
+  ];
+
+  return $requirements;
+}

--- a/gt_gin.module
+++ b/gt_gin.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for gt_gin module.
+ */
+
+use Drupal\gin\GinSettings;


### PR DESCRIPTION
Adds the basic files needed to make the module ✨installable✨.
- Declares dependencies on:
    -  Gin: via `composer.json` and `.install`
    -  Gin Toolbar: via `composer.json` and `info.yml`
- Added to README: rough draft on getting started with development, needs testing and filling out sections

@konfuzed, I am soooo Drupal rusty, let me know if anything obvious needs fixin'. 

Closes #1 